### PR TITLE
Replace as many as built in browsers with SFSafariViewController

### DIFF
--- a/Monkey/Classes/Module/DiscoveryModule/GithubAwards/GitHubAwardsViewController.h
+++ b/Monkey/Classes/Module/DiscoveryModule/GithubAwards/GitHubAwardsViewController.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+@import SafariServices;
+
 @interface GitHubAwardsViewController : UIViewController
 
 @end

--- a/Monkey/Classes/Module/DiscoveryModule/GithubAwards/GitHubAwardsViewController.m
+++ b/Monkey/Classes/Module/DiscoveryModule/GithubAwards/GitHubAwardsViewController.m
@@ -8,8 +8,8 @@
 //
 
 #import "GitHubAwardsViewController.h"
-#import "WebViewController.h"
-@interface GitHubAwardsViewController ()<UITableViewDataSource,UITableViewDelegate> {
+
+@interface GitHubAwardsViewController ()<UITableViewDataSource,UITableViewDelegate, SFSafariViewControllerDelegate> {
     UITableView *tableView1;
     NSArray *rankCategorys;
 }
@@ -74,10 +74,14 @@
 #pragma mark - Actions
 
 - (void)footerButtonAction
-{
-    WebViewController *viewController=[[WebViewController alloc] init];
-    viewController.urlString=@"http://github-awards.com/";
-    [self.navigationController pushViewController:viewController animated:YES];
+{    
+    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://github-awards.com/"]];
+    if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+        [self presentViewController:sfvc animated:YES completion:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:URL];
+    }
 }
 
 #pragma mark - UITableViewDataSource  &UITableViewDelegate
@@ -106,11 +110,21 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    WebViewController *viewController=[[WebViewController alloc] init];
     NSArray *webViewRankCategorys=@[@"world",@"country",@"city"];
-    viewController.urlString=[NSString stringWithFormat:@"http://github-awards.com/users?type=%@",webViewRankCategorys[indexPath.section]];
-    [self.navigationController pushViewController:viewController animated:YES];
     
+    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://github-awards.com/users?type=%@",webViewRankCategorys[indexPath.section]]];
+    if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+        [self presentViewController:sfvc animated:YES completion:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:URL];
+    }
+    
+    
+}
+
+- (void)safariViewControllerDidFinish:(nonnull SFSafariViewController *)controller {
+    [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/Monkey/Classes/Module/DiscoveryModule/GithubAwards/GitHubAwardsViewController.m
+++ b/Monkey/Classes/Module/DiscoveryModule/GithubAwards/GitHubAwardsViewController.m
@@ -110,9 +110,9 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    NSArray *webViewRankCategorys=@[@"world",@"country",@"city"];
+    NSArray *safariWebViewRankCategorys=@[@"world",@"country",@"city"];
     
-    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://github-awards.com/users?type=%@",webViewRankCategorys[indexPath.section]]];
+    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://github-awards.com/users?type=%@",safariWebViewRankCategorys[indexPath.section]]];
     if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
         SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
         [self presentViewController:sfvc animated:YES completion:nil];

--- a/Monkey/Classes/Module/DiscoveryModule/GithubRanking/GitHubRankingViewController.h
+++ b/Monkey/Classes/Module/DiscoveryModule/GithubRanking/GitHubRankingViewController.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+@import SafariServices;
+
 @interface GitHubRankingViewController : UIViewController
 
 @end

--- a/Monkey/Classes/Module/DiscoveryModule/GithubRanking/GitHubRankingViewController.m
+++ b/Monkey/Classes/Module/DiscoveryModule/GithubRanking/GitHubRankingViewController.m
@@ -111,8 +111,8 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    NSArray *webViewRankCategorys=@[@"repositories",@"users",@"organizations"];
-    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://githubranking.com/%@",webViewRankCategorys[indexPath.section]]];
+    NSArray *safariWebViewRankCategorys=@[@"repositories",@"users",@"organizations"];
+    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://githubranking.com/%@",safariWebViewRankCategorys[indexPath.section]]];
     if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
         SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
         [self presentViewController:sfvc animated:YES completion:nil];

--- a/Monkey/Classes/Module/DiscoveryModule/GithubRanking/GitHubRankingViewController.m
+++ b/Monkey/Classes/Module/DiscoveryModule/GithubRanking/GitHubRankingViewController.m
@@ -7,8 +7,8 @@
 //
 
 #import "GitHubRankingViewController.h"
-#import "WebViewController.h"
-@interface GitHubRankingViewController ()<UITableViewDataSource,UITableViewDelegate> {
+
+@interface GitHubRankingViewController ()<UITableViewDataSource,UITableViewDelegate, SFSafariViewControllerDelegate> {
     UITableView *tableView1;
     NSArray *rankCategorys;
 }
@@ -75,9 +75,13 @@
 
 - (void)footerButtonAction
 {
-    WebViewController *viewController=[[WebViewController alloc] init];
-    viewController.urlString=@"http://githubranking.com/";
-    [self.navigationController pushViewController:viewController animated:YES];
+    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://githubranking.com/"]];
+    if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+        [self presentViewController:sfvc animated:YES completion:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:URL];
+    }
 }
 
 #pragma mark - UITableViewDataSource  &UITableViewDelegate
@@ -107,10 +111,18 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    WebViewController *viewController=[[WebViewController alloc] init];
     NSArray *webViewRankCategorys=@[@"repositories",@"users",@"organizations"];
-    viewController.urlString=[NSString stringWithFormat:@"http://githubranking.com/%@",webViewRankCategorys[indexPath.section]];
-    [self.navigationController pushViewController:viewController animated:YES];
+    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://githubranking.com/%@",webViewRankCategorys[indexPath.section]]];
+    if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+        [self presentViewController:sfvc animated:YES completion:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:URL];
+    }
+}
+
+- (void)safariViewControllerDidFinish:(nonnull SFSafariViewController *)controller {
+    [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/Monkey/Classes/Module/PersonalModule/AboutModule/AboutViewController.h
+++ b/Monkey/Classes/Module/PersonalModule/AboutModule/AboutViewController.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+@import SafariServices;
+
 @interface AboutViewController : UIViewController
 
 @end

--- a/Monkey/Classes/Module/PersonalModule/AboutModule/AboutViewController.m
+++ b/Monkey/Classes/Module/PersonalModule/AboutModule/AboutViewController.m
@@ -9,7 +9,6 @@
 #import "AboutViewController.h"
 #import "UserDetailViewController.h"
 #import "RepositoryDetailViewController.h"
-#import "WebViewController.h"
 @interface AboutViewController () <SFSafariViewControllerDelegate> {
     UILabel *titleText;
 }

--- a/Monkey/Classes/Module/PersonalModule/AboutModule/AboutViewController.m
+++ b/Monkey/Classes/Module/PersonalModule/AboutModule/AboutViewController.m
@@ -10,7 +10,7 @@
 #import "UserDetailViewController.h"
 #import "RepositoryDetailViewController.h"
 #import "WebViewController.h"
-@interface AboutViewController () {
+@interface AboutViewController () <SFSafariViewControllerDelegate> {
     UILabel *titleText;
 }
 
@@ -137,9 +137,13 @@
 
 - (void)buttonLicenseAction
 {
-    WebViewController *web=[[WebViewController alloc] init];
-    web.urlString=@"https://github.com/coderyi/Monkey/blob/master/Documents/Monkey_opensource_components.md";
-    [self.navigationController pushViewController:web animated:YES];
+    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"https://github.com/coderyi/Monkey/blob/master/Documents/Monkey_opensource_components.md"]];
+    if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+        [self presentViewController:sfvc animated:YES completion:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:URL];
+    }
 
 }
 

--- a/Monkey/Classes/Module/RepositoriesModule/ViewControllers/RepositoryDetailViewController.h
+++ b/Monkey/Classes/Module/RepositoriesModule/ViewControllers/RepositoryDetailViewController.h
@@ -8,6 +8,9 @@
 
 #import <UIKit/UIKit.h>
 #import "RepositoryModel.h"
+
+@import SafariServices;
+
 @interface RepositoryDetailViewController : UIViewController
 @property(nonatomic,strong) RepositoryModel *model;
 @end

--- a/Monkey/Classes/Module/RepositoriesModule/ViewControllers/RepositoryDetailViewController.m
+++ b/Monkey/Classes/Module/RepositoriesModule/ViewControllers/RepositoryDetailViewController.m
@@ -218,28 +218,26 @@
 - (void)nameBtAction
 {
     if (_model.html_url.length>0  ) {
-        WebViewController *web=[[WebViewController alloc] init];
-        web.urlString=_model.html_url;
-        [self.navigationController pushViewController:web animated:YES];
-        
-    }
-    
-    
-    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://google.com"]];
-    if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
-        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
-        [self presentViewController:sfvc animated:YES completion:nil];
-    } else {
-        [[UIApplication sharedApplication] openURL:URL];
+        NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"%@", _model.html_url]];
+        if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+            SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+            [self presentViewController:sfvc animated:YES completion:nil];
+        } else {
+            [[UIApplication sharedApplication] openURL:URL];
+        }
     }
 }
 
 - (void)ownerBtAction
 {
     if (_model.user.html_url.length>0  ) {
-        WebViewController *web=[[WebViewController alloc] init];
-        web.urlString=_model.user.html_url;
-        [self.navigationController pushViewController:web animated:YES];
+        NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"%@", _model.user.html_url]];
+        if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+            SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+            [self presentViewController:sfvc animated:YES completion:nil];
+        } else {
+            [[UIApplication sharedApplication] openURL:URL];
+        }
     }
 }
 
@@ -308,9 +306,13 @@
 - (void)homePageAction
 {
     if (_model.homepage.length>0  ) {
-        WebViewController *web=[[WebViewController alloc] init];
-        web.urlString=_model.homepage;
-        [self.navigationController pushViewController:web animated:YES];
+        NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"%@", _model.homepage]];
+        if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+            SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+            [self presentViewController:sfvc animated:YES completion:nil];
+        } else {
+            [[UIApplication sharedApplication] openURL:URL];
+        }
     }
 }
 

--- a/Monkey/Classes/Module/RepositoriesModule/ViewControllers/RepositoryDetailViewController.m
+++ b/Monkey/Classes/Module/RepositoriesModule/ViewControllers/RepositoryDetailViewController.m
@@ -15,7 +15,7 @@
 #import "UserDetailViewController.h"
 #import "RepositoryDetailDataSource.h"
 #import "RepositoryDetailViewModel.h"
-@interface RepositoryDetailViewController ()<UITableViewDelegate> {
+@interface RepositoryDetailViewController ()<UITableViewDelegate, SFSafariViewControllerDelegate> {
     
     UITableView *tableView;
     YiRefreshHeader *refreshHeader;
@@ -221,6 +221,16 @@
         WebViewController *web=[[WebViewController alloc] init];
         web.urlString=_model.html_url;
         [self.navigationController pushViewController:web animated:YES];
+        
+    }
+    
+    
+    NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"http://google.com"]];
+    if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+        SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+        [self presentViewController:sfvc animated:YES completion:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:URL];
     }
 }
 

--- a/Monkey/Classes/Module/UsersModule/ViewControllers/UserDetailViewController.h
+++ b/Monkey/Classes/Module/UsersModule/ViewControllers/UserDetailViewController.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 #import "UserModel.h"
+@import SafariServices;
+
 @interface UserDetailViewController : UIViewController
 @property(nonatomic,strong) UserModel *userModel;
 @end

--- a/Monkey/Classes/Module/UsersModule/ViewControllers/UserDetailViewController.m
+++ b/Monkey/Classes/Module/UsersModule/ViewControllers/UserDetailViewController.m
@@ -22,7 +22,7 @@
 #import "LoginWebViewController.h"
 #import "AESCrypt.h"
 
-@interface UserDetailViewController ()<UITableViewDelegate,UIAlertViewDelegate> {
+@interface UserDetailViewController ()<UITableViewDelegate,UIAlertViewDelegate, SFSafariViewControllerDelegate> {
     UITableView *tableView;
     YiRefreshHeader *refreshHeader;
     YiRefreshFooter *refreshFooter;
@@ -219,11 +219,14 @@
 #pragma mark - Actions
 - (void)loginButtonAction
 {
-
     if (_userModel.html_url.length>0) {
-        WebViewController *web=[[WebViewController alloc] init];
-        web.urlString=_userModel.html_url;
-        [self.navigationController pushViewController:web animated:YES];
+        NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"%@", _userModel.html_url]];
+        if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+            SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+            [self presentViewController:sfvc animated:YES completion:nil];
+        } else {
+            [[UIApplication sharedApplication] openURL:URL];
+        }
     }
 }
 
@@ -337,9 +340,13 @@
 - (void)blogAction
 {
     if (_userModel.blog.length>0  ) {
-        WebViewController *web=[[WebViewController alloc] init];
-        web.urlString=_userModel.blog;
-        [self.navigationController pushViewController:web animated:YES];
+        NSURL *URL = [NSURL URLWithString:[NSString stringWithFormat:@"%@", _userModel.blog]];
+        if ([[UIDevice currentDevice].systemVersion hasPrefix:@"9"]) {
+            SFSafariViewController *sfvc = [[SFSafariViewController alloc] initWithURL:URL];
+            [self presentViewController:sfvc animated:YES completion:nil];
+        } else {
+            [[UIApplication sharedApplication] openURL:URL];
+        }
     }
 }
 
@@ -529,6 +536,10 @@
         [self.navigationController pushViewController:detail animated:YES];
     }
 
+}
+
+- (void)safariViewControllerDidFinish:(nonnull SFSafariViewController *)controller {
+    [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
The previous implementation limited the user to navigate within the app, if the user clicks on any URL. Starting from iOS 9, Apple now provides a built-in web view controller of similar functionality named SFSafariViewController. Now, the user should be able to navigate on Safari web browser, and they can go back to the app by clicking on top left corner of the status bar. 