### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Documents/Monkey_opensource_components.md
+++ b/Documents/Monkey_opensource_components.md
@@ -1,4 +1,4 @@
-###Open Source Components
+### Open Source Components
 
 [NetworkEye](https://github.com/coderyi/NetworkEye)
 

--- a/Documents/Monkey_updatefile.md
+++ b/Documents/Monkey_updatefile.md
@@ -1,5 +1,5 @@
-#更新日志
-######2015.10.29
+# 更新日志
+###### 2015.10.29
 1.去除octokit，follow和star操作都采用token来做，修改相关VC，并且network增加相应的请求
 
 2.采用oauth2登录，去除LoginViewController的octokit登录，增加LoginWebViewController的oauth2登录
@@ -51,7 +51,7 @@ UserModel修改一下就好
 //    model.location =  [dict objectForKey:@"location"];
 </pre>
 
-######2015.9.21
+###### 2015.9.21
 
 主要最低支持版本iOS7.0提高至iOS8.0
 

--- a/Monkey_API.md
+++ b/Monkey_API.md
@@ -5,7 +5,7 @@
 
 API的hostname是https://api.github.com
 
-###Search users（搜索用户）
+### Search users（搜索用户）
 
 官方地址:https://developer.github.com/v3/search/#search-users
 
@@ -13,7 +13,7 @@ API的hostname是https://api.github.com
 API简单说明:GET /search/users
 
 示例:
-#####Users排名
+##### Users排名
 世界users排名objective-c followers
 
 https://api.github.com/search/users?q=language:objective-c&sort=followers&order=desc
@@ -33,11 +33,11 @@ https://api.github.com/search/users?sort=followers&page=1&q=location:guangzhou
 城市users排名分语言objective-c followers
 
 https://api.github.com/search/users?sort=followers&page=1&q=location:beijing+language:Objective-C
-#####查找用户
+##### 查找用户
 
 https://api.github.com/search/users?q=coderyi
 
-###Search repositories（搜索仓库）
+### Search repositories（搜索仓库）
 
 官方地址:https://developer.github.com/v3/search/#search-repositories
 
@@ -50,7 +50,7 @@ API简单说明:GET /search/repositories
 
 https://api.github.com/search/repositories?q=language:objective-c&sort=stars&order=desc
 
-###Get a single user（获取用户的详细信息）
+### Get a single user（获取用户的详细信息）
 
 
 
@@ -64,7 +64,7 @@ API简单说明:GET /users/:username
 
 某用户的详细信息   https://api.github.com/users/coderyi
 
-###List user repositories（获取用户所有的仓库）
+### List user repositories（获取用户所有的仓库）
 
 官方文档地址:https://developer.github.com/v3/repos/#list-user-repositories
 作用:List user repositories
@@ -79,7 +79,7 @@ https://api.github.com/users/coderyi/repos?sort=updated
 
 
 
-###List followers of a user（获取用户的粉丝列表）
+### List followers of a user（获取用户的粉丝列表）
 
 官方文档地址:https://developer.github.com/v3/users/followers/#list-followers-of-a-user
 
@@ -93,7 +93,7 @@ https://api.github.com/users/coderyi/followers
 
 
 
-###List users followed by another user（获取用户关注的人列表）
+### List users followed by another user（获取用户关注的人列表）
 官方文档地址:https://developer.github.com/v3/users/followers/#list-users-followed-by-another-user
 
 API简单说明:GET /users/:username/following
@@ -104,7 +104,7 @@ API简单说明:GET /users/:username/following
 
 https://api.github.com/users/coderyi/following
 
-###Get(查看项目详细)
+### Get(查看项目详细)
 官方文档地址:https://developer.github.com/v3/repos/#get
 
 API简单说明:GET /repos/:owner/:repo
@@ -115,7 +115,7 @@ API简单说明:GET /repos/:owner/:repo
 
 https://api.github.com/repos/coderyi/yirefresh
 
-###List contributors（所有对这个项目有贡献的人）
+### List contributors（所有对这个项目有贡献的人）
 官方文档地址:https://developer.github.com/v3/repos/#list-contributors
 
 作用:List contributors 
@@ -128,7 +128,7 @@ API简单说明:GET /repos/:owner/:repo/contributors
 
 https://api.github.com/repos/aufree/trip-to-iOS/contributors
 
-###List forks（所有forks这个repos的repos）
+### List forks（所有forks这个repos的repos）
 官方文档地址:https://developer.github.com/v3/repos/forks/#list-forks
 
 作用:List forks 
@@ -139,7 +139,7 @@ API简单说明: GET /repos/:owner/:repo/forks
 
 https://api.github.com/repos/coderyi/yiswitch/forks
 
-###List Stargazers（所有star这个仓库的人）
+### List Stargazers（所有star这个仓库的人）
 官方文档地址:https://developer.github.com/v3/activity/starring/#list-stargazers
 
 作用:List Stargazers 

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -23,7 +23,7 @@ Monkey Mac地址:[https://github.com/coderyi/MonkeyForMac](https://github.com/co
 另外, 你能够获取Android版本[andyiac](https://github.com/andyiac) 写的 [GitHot](https://github.com/andyiac/githot) ，下载链接 [ fir.im/githot](http://fir.im/githot) .    
 另外一个Android版本，[monkey-android](https://github.com/yeungeek/monkey-android), 来自[yeungeek](https://github.com/yeungeek)
 
-##Monkey for GitHub
+## Monkey for GitHub
 
 
 Monkey是一个GitHub第三方客户端，Monkey取名就是表示我们程序猿的意思。它包括下面这些功能
@@ -43,12 +43,12 @@ build的话使用如下命令
 $ git clone https://github.com/coderyi/Monkey.git
 $ pod install
 </pre>
-##Monkey架构
+## Monkey架构
 
 ![点击放大](https://raw.githubusercontent.com/coderyi/Monkey/master/Documents/Monkey_architecture_img1.png)
 
 
-##GitHub Top Users Repositories
+## GitHub Top Users Repositories
 **[GitHub排名前50的Objective-C开发者(Objective-C top 50 GitHub developers)](https://github.com/coderyi/Monkey/blob/master/github_top_users_repositories/github_top_users_objective-c_world.md)**
 
 这是GitHub在世界范围内排名前50的Objective-C程序员，并且列出相关信息，从而可以走近他们的程序世界。
@@ -56,17 +56,17 @@ $ pod install
 数据来自GitHub的API以及自己整理的相关内容。
 
 这个列表是我做[Monkey for GitHub](https://github.com/coderyi/Monkey)这个开源的GitHub第三方客户端的衍生品，欢迎交流意见。
-##关于开源
-####运行
+## 关于开源
+#### 运行
 支持iOS7.0+，支持iPhone的各个尺寸，支持竖屏；可以使用的是Xcode7.0+
 
-####Monkey API
+#### Monkey API
 我整理Monkey for GitHub的所有API，并做了一些说明和示例，希望能够帮助到您。
 
 地址是：https://github.com/coderyi/Monkey/blob/master/Monkey_API.md
 
 
-####项目中使用的开源组件
+#### 项目中使用的开源组件
 [NetworkEye](https://github.com/coderyi/NetworkEye)
 
 NetworkEye,a iOS network debug library,It can monitor all HTTP requests within the App and displays all information related to the request.
@@ -100,7 +100,7 @@ Asynchronous image downloader with cache support with an UIImageView category
 另外项目中使用了友盟的相关服务。
 
 
-##LICENSE
+## LICENSE
 此开源项目可以用来做任何事情除了原封不动的分发到App Store。
 
 copyright (c) 2015 coderyi.all rights reserved.
@@ -111,7 +111,7 @@ copyright (c) 2015 coderyi.all rights reserved.
 
 
 
-##联系我
+## 联系我
 对于Monkey，你可以随意提交；如果想加入更多的开发，欢迎联系我！
 
 blog:[http://www.coderyi.com/](http://www.coderyi.com/)
@@ -121,7 +121,7 @@ GitHub:[https://github.com/coderyi](https://github.com/coderyi)
 email:coderyi@foxmail.com
 
 
-##App预览
+## App预览
 
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
